### PR TITLE
Docs: specified minimum cursor line movement

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -77,7 +77,8 @@ impl Command for MoveTo {
 ///
 /// # Notes
 ///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * Moves a minimum of 1 line.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToNextLine(pub u16);
 
@@ -97,7 +98,8 @@ impl Command for MoveToNextLine {
 ///
 /// # Notes
 ///
-/// Commands must be executed/queued for execution otherwise they do nothing.
+/// * Moves a minimum of 1 line.
+/// * Commands must be executed/queued for execution otherwise they do nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoveToPreviousLine(pub u16);
 


### PR DESCRIPTION
this pr specifies the minimum cursor line movement in commands `cursor::MoveToNextLine` and `cursor::MoveToPreviousLine`
see #599

are there any exceptions to the behavior outlined in #599? i don't want to make a blanket statement that they will always move a minimum of 1 line, given 0.